### PR TITLE
fix(connector): mongodb server ping

### DIFF
--- a/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/verifier/MongoConnectorVerifierExtension.java
+++ b/app/connector/mongodb/src/main/java/io/syndesis/connector/mongo/verifier/MongoConnectorVerifierExtension.java
@@ -26,6 +26,7 @@ import org.apache.camel.component.extension.verifier.DefaultComponentVerifierExt
 import org.apache.camel.component.extension.verifier.ResultBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorBuilder;
 import org.apache.camel.component.extension.verifier.ResultErrorHelper;
+import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,8 @@ public class MongoConnectorVerifierExtension extends DefaultComponentVerifierExt
         LOG.info("Testing connection against {}", connectionURI);
         try (MongoClient mongoClient = new MongoClient(connectionURI)) {
             // Just ping the server
-            mongoClient.getConnectPoint();
+            mongoClient.getDatabase(connectionURI.getDatabase()).runCommand(Document.parse("{ ping: 1 }"));
+            LOG.info("Testing connection successful!");
         } catch (MongoSecurityException e) {
             ResultErrorBuilder errorBuilder = ResultErrorBuilder.withCodeAndDescription(
                 VerificationError.StandardCode.AUTHENTICATION,

--- a/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
+++ b/app/connector/mongodb/src/test/java/io/syndesis/connector/mongo/verifier/MongoDBVerifierTest.java
@@ -93,7 +93,7 @@ public class MongoDBVerifierTest extends MongoDBConnectorTestSupport {
             CONNECTOR_ID, params);
         ComponentVerifierExtension.Result result = VERIFIER
             .resolveComponentVerifierExtension(this.context, SCHEME)
-            .verify(ComponentVerifierExtension.Scope.CONNECTIVITY, params);
+            .verify(ComponentVerifierExtension.Scope.PARAMETERS, params);
         //Then
         assertEquals(Verifier.Status.ERROR, response.get(0).getStatus());
         assertEquals(ComponentVerifierExtension.Result.Status.ERROR, result.getStatus());


### PR DESCRIPTION
Replaced the method to ping a mongodb server, new mongodb-driver brought in by Spring BOM uses different approach. This is going to be replaced in 7.6 by camel upstream component changed logic, ported here to allow further development.